### PR TITLE
Save States

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ wasm-bindgen = "0.2.100"
 num-derive = "0.4.2"
 log = "0.4.27"
 memory-macros = {path = "memory-macros"}
+serde = { version = "1.0", features = ["derive"] }
+serde_with = "3.12.0"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/memory-macros/src/lib.rs
+++ b/memory-macros/src/lib.rs
@@ -235,7 +235,7 @@ fn create_bit_field(name: Ident, segment_size: Lit, bit_fields: &IORegister) -> 
     let (_, segment_type) = parse_segment_size(&segment_size, &name.span());
 
     let expanded = quote! {
-        #[derive(Serialize)]
+        #[derive(Default, Serialize, Deserialize)]
         pub struct #name {
             #[serde(skip)]
             pub memory: Option<Rc<RefCell<GbaMem>>>,
@@ -307,7 +307,7 @@ fn create_multiple_bit_field(name: Ident, segment_size: Lit, bit_fields: &Multip
     };
 
     let expanded = quote! {
-        #[derive(Serialize)]
+        #[derive(Default, Serialize, Deserialize)]
         pub struct #name {
             #[serde(skip)]
             pub memory: Option<Rc<RefCell<GbaMem>>>,

--- a/memory-macros/src/lib.rs
+++ b/memory-macros/src/lib.rs
@@ -235,7 +235,9 @@ fn create_bit_field(name: Ident, segment_size: Lit, bit_fields: &IORegister) -> 
     let (_, segment_type) = parse_segment_size(&segment_size, &name.span());
 
     let expanded = quote! {
+        #[derive(Serialize)]
         pub struct #name {
+            #[serde(skip)]
             pub memory: Option<Rc<RefCell<GbaMem>>>,
         }
 
@@ -305,7 +307,9 @@ fn create_multiple_bit_field(name: Ident, segment_size: Lit, bit_fields: &Multip
     };
 
     let expanded = quote! {
+        #[derive(Serialize)]
         pub struct #name {
+            #[serde(skip)]
             pub memory: Option<Rc<RefCell<GbaMem>>>,
             pub index: usize
         }

--- a/memory-macros/src/lib.rs
+++ b/memory-macros/src/lib.rs
@@ -236,7 +236,7 @@ fn create_bit_field(name: Ident, segment_size: Lit, bit_fields: &IORegister) -> 
 
     let expanded = quote! {
         pub struct #name {
-            pub memory: Rc<RefCell<GbaMem>>,
+            pub memory: Option<Rc<RefCell<GbaMem>>>,
         }
 
         impl #name {
@@ -245,28 +245,36 @@ fn create_bit_field(name: Ident, segment_size: Lit, bit_fields: &IORegister) -> 
 
             pub fn new() -> #name {
                 return #name {
-                    memory: Rc::new(RefCell::new(vec![0; #segment_size]))
+                    memory: None,
                 };
             }
 
             pub fn register(&mut self, mem: &Rc<RefCell<Vec<u8>>>) {
-                self.memory = mem.clone();
+                self.memory = Some(mem.clone());
             }
 
             pub fn get_register(&self) -> #segment_type {
                 let mut value: #segment_type = 0;
-                let mem_ref = self.memory.borrow();
-                for i in 0..#name::SEGMENT_SIZE {
-                    value |= (mem_ref[#name::SEGMENT_INDEX + (i as usize)] as #segment_type) <<  (i * 8);
+                if let Some(mem) = &self.memory {
+                    let mem_ref = mem.borrow();
+                    for i in 0..#name::SEGMENT_SIZE {
+                        value |= (mem_ref[#name::SEGMENT_INDEX + (i as usize)] as #segment_type) <<  (i * 8);
+                    }
+                } else {
+                    panic!("IO register was accessed without being registered");
                 }
 
                 return value;
             }
 
             pub fn set_register(&self, value: u32) {
-                let mut mem_ref = self.memory.borrow_mut();
-                for i in 0..#name::SEGMENT_SIZE {
-                    mem_ref[#name::SEGMENT_INDEX + (i as usize)] = ((value & (0xFFu32 << (i * 8))) >> (i * 8)) as u8;
+                if let Some(mem) = &self.memory {
+                    let mut mem_ref = mem.borrow_mut();
+                    for i in 0..#name::SEGMENT_SIZE {
+                        mem_ref[#name::SEGMENT_INDEX + (i as usize)] = ((value & (0xFFu32 << (i * 8))) >> (i * 8)) as u8;
+                    }
+                } else {
+                    panic!("IO register was accessed without being registered");
                 }
             }
 
@@ -298,7 +306,7 @@ fn create_multiple_bit_field(name: Ident, segment_size: Lit, bit_fields: &Multip
 
     let expanded = quote! {
         pub struct #name {
-            pub memory: Rc<RefCell<GbaMem>>,
+            pub memory: Option<Rc<RefCell<GbaMem>>>,
             pub index: usize
         }
 
@@ -308,29 +316,33 @@ fn create_multiple_bit_field(name: Ident, segment_size: Lit, bit_fields: &Multip
 
             pub fn new(index: usize) -> #name {
                 return #name {
-                    memory: Rc::new(RefCell::new(Vec::new())),
+                    memory: None,
                     index: index
                 };
             }
 
             pub fn register(&mut self, mem: &Rc<RefCell<Vec<u8>>>) {
-                self.memory = mem.clone();
+                self.memory = Some(mem.clone());
             }
 
             pub fn get_register(&self) -> #segment_type {
                 let mut value: #segment_type = 0;
-                let mem_ref = self.memory.borrow();
-                for i in 0..#name::SEGMENT_SIZE {
-                    value |= (mem_ref[#name::SEGMENT_INDICIES[self.index] + (i as usize)] as #segment_type) <<  (i * 8);
+                if let Some(mem) = &self.memory {
+                    let mem_ref = mem.borrow();
+                    for i in 0..#name::SEGMENT_SIZE {
+                        value |= (mem_ref[#name::SEGMENT_INDICIES[self.index] + (i as usize)] as #segment_type) <<  (i * 8);
+                    }
                 }
 
                 return value;
             }
 
             pub fn set_register(&self, value: u32) {
-                let mut mem_ref = self.memory.borrow_mut();
-                for i in 0..#name::SEGMENT_SIZE {
-                    mem_ref[#name::SEGMENT_INDICIES[self.index] + (i as usize)] = ((value & (0xFFu32 << (i * 8))) >> (i * 8)) as u8;
+                if let Some(mem) = &self.memory {
+                    let mut mem_ref = mem.borrow_mut();
+                    for i in 0..#name::SEGMENT_SIZE {
+                        mem_ref[#name::SEGMENT_INDICIES[self.index] + (i as usize)] = ((value & (0xFFu32 << (i * 8))) >> (i * 8)) as u8;
+                    }
                 }
             }
 

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -18,6 +18,7 @@ use super::{condition::Condition};
 use crate::operations::instruction::Instruction;
 use std::borrow::{BorrowMut};
 use crate::memory::memory_bus::MemoryBus;
+use serde::{Serialize, Deserialize};
 
 
 pub const ARM_PC: u8 = 15;
@@ -120,6 +121,7 @@ pub enum ThumbInstructionFormat {
     Undefined
 }
 
+#[derive(Serialize)]
 pub struct CPU {   
     registers: [u32; 31],
     spsr: [ProgramStatusRegister; 7],

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -121,7 +121,7 @@ pub enum ThumbInstructionFormat {
     Undefined
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CPU {   
     registers: [u32; 31],
     spsr: [ProgramStatusRegister; 7],
@@ -265,6 +265,12 @@ impl CPU {
                 opcode: opcode
             })
         }
+    }
+
+    pub fn get_pc(&self) -> u32 {
+        let current_pc = if self.get_instruction_set() == InstructionSet::Arm { ARM_PC } else { THUMB_PC };
+        let pc_contents = self.get_register(current_pc);
+        return pc_contents;
     }
 
     pub fn fetch(&mut self, bus: &mut MemoryBus) -> usize {

--- a/src/cpu/program_status_register.rs
+++ b/src/cpu/program_status_register.rs
@@ -1,4 +1,6 @@
-#[derive(Clone, Copy, Debug)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 pub struct ConditionFlags {
     pub negative: bool,
     pub zero: bool,
@@ -17,7 +19,7 @@ impl From<u32> for ConditionFlags {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 pub struct ControlBits {
     pub fiq_disable: bool,
     pub irq_disable: bool,
@@ -36,7 +38,7 @@ impl From<u32> for ControlBits {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 pub struct ProgramStatusRegister {
     pub flags: ConditionFlags,
     pub reserved: u32,

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use std::fmt;
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DMAChannel {
     pub source_address: DMASourceAddress,
     pub destination_address: DMADestinationAddress,
@@ -147,7 +147,7 @@ impl DMAChannel {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DMAController {
     pub dma_channels: [DMAChannel; 4],
     pub hblanking: bool,

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -3,7 +3,9 @@ use crate::interrupts::interrupts::Interrupts;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::fmt;
+use serde::{Serialize, Deserialize};
 
+#[derive(Serialize)]
 pub struct DMAChannel {
     pub source_address: DMASourceAddress,
     pub destination_address: DMADestinationAddress,
@@ -145,6 +147,7 @@ impl DMAChannel {
     }
 }
 
+#[derive(Serialize)]
 pub struct DMAController {
     pub dma_channels: [DMAChannel; 4],
     pub hblanking: bool,

--- a/src/gamepak/flash.rs
+++ b/src/gamepak/flash.rs
@@ -1,8 +1,8 @@
 use crate::memory::memory_map::MemoryMap;
 use crate::gamepak::BackupType;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub enum FlashCommands {
     StartID = 0x90,
     EndID = 0xF0,
@@ -28,7 +28,7 @@ impl FlashCommands {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 enum FlashPhase {
     Phase1,
     Phase2,
@@ -36,7 +36,7 @@ enum FlashPhase {
     CommandParameter
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Flash {
     phase: FlashPhase,
     enable_id: bool,
@@ -64,8 +64,6 @@ impl Flash {
 }
 
 impl MemoryMap {
-    
-
     pub fn read_flash(&self, address: u32) -> u8 {
         if self.flash.enable_id && (address & 0xFFFF) < 2 {
             if self.backup_type == BackupType::Flash128K {
@@ -98,8 +96,6 @@ impl MemoryMap {
             }
         }
     }
-
-    
 
     fn run_command(&mut self, address: u32, value: u8) {
         let flash_command = FlashCommands::from(value);

--- a/src/gamepak/flash.rs
+++ b/src/gamepak/flash.rs
@@ -1,6 +1,8 @@
 use crate::memory::memory_map::MemoryMap;
 use crate::gamepak::BackupType;
+use serde::Serialize;
 
+#[derive(Serialize)]
 pub enum FlashCommands {
     StartID = 0x90,
     EndID = 0xF0,
@@ -26,6 +28,7 @@ impl FlashCommands {
     }
 }
 
+#[derive(Serialize)]
 enum FlashPhase {
     Phase1,
     Phase2,
@@ -33,6 +36,7 @@ enum FlashPhase {
     CommandParameter
 }
 
+#[derive(Serialize)]
 pub struct Flash {
     phase: FlashPhase,
     enable_id: bool,

--- a/src/gamepak/mod.rs
+++ b/src/gamepak/mod.rs
@@ -1,9 +1,10 @@
 use std::io::prelude::*;
 use std::fs::File;
+use serde::Serialize;
 
 pub mod flash;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Serialize, Debug, PartialEq, Clone, Copy)]
 pub enum BackupType {
     Sram,
     Eeprom,
@@ -12,9 +13,13 @@ pub enum BackupType {
     Error
 }
 
+#[derive(Serialize)]
 pub struct GamePack {
+    #[serde(skip)]
     pub rom: Vec<u8>,
+    #[serde(skip)]
     pub bios: Vec<u8>,
+    #[serde(skip)]
     pub save_data: Vec<u8>,
     pub title: String,
     pub game_code: String,

--- a/src/gamepak/mod.rs
+++ b/src/gamepak/mod.rs
@@ -1,10 +1,10 @@
 use std::io::prelude::*;
 use std::fs::File;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 pub mod flash;
 
-#[derive(Serialize, Debug, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 pub enum BackupType {
     Sram,
     Eeprom,
@@ -13,7 +13,7 @@ pub enum BackupType {
     Error
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GamePack {
     #[serde(skip)]
     pub rom: Vec<u8>,

--- a/src/gba/mod.rs
+++ b/src/gba/mod.rs
@@ -9,7 +9,7 @@ use crate::timers::timer::TimerHandler;
 use crate::{gamepak::GamePack, gamepak::BackupType};
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GBA {
     pub cpu: CPU,
     pub gpu: GPU,
@@ -43,49 +43,7 @@ impl GBA {
             dma_control: DMAController::new()
         };
 
-        temp.gpu.register(&temp.memory_bus.mem_map.memory);
-        temp.key_status.register(&temp.memory_bus.mem_map.memory);
-        temp.ket_interrupt_control.register(&temp.memory_bus.mem_map.memory);
-        temp.interrupt_handler.ime_interrupt.register(&temp.memory_bus.mem_map.memory);
-        temp.interrupt_handler.ie_interrupt.register(&temp.memory_bus.mem_map.memory);
-        temp.interrupt_handler.if_interrupt.register(&temp.memory_bus.mem_map.memory);
-        temp.timer_handler.register(&temp.memory_bus.mem_map.memory);
-        temp.memory_bus.cycle_clock.register(&temp.memory_bus.mem_map.memory);
-        temp.dma_control.register(&temp.memory_bus.mem_map.memory);
-
-        // setup the PC
-        temp.cpu.set_register(ARM_PC, pc_address);
-        temp.cpu.set_register(ARM_SP, 0x03007F00);
-
-        // setup the SPs'
-        temp.cpu.set_operating_mode(OperatingMode::Interrupt);
-        temp.cpu.set_register(ARM_SP, 0x03007FA0);
-
-        temp.cpu.set_operating_mode(OperatingMode::FastInterrupt);
-        temp.cpu.set_register(ARM_SP, 0x03007F00);
-
-        temp.cpu.set_operating_mode(OperatingMode::User);
-        temp.cpu.set_register(ARM_SP, 0x03007F00);
-
-        temp.cpu.set_operating_mode(OperatingMode::Supervisor);
-        temp.cpu.set_register(ARM_SP, 0x03007FE0);
-
-        temp.cpu.set_operating_mode(OperatingMode::Abort);
-        temp.cpu.set_register(ARM_SP, 0x03007F00);
-
-        temp.cpu.set_operating_mode(OperatingMode::Undefined);
-        temp.cpu.set_register(ARM_SP, 0x03007F00);
-
-        temp.cpu.set_operating_mode(OperatingMode::Supervisor);
-
-        temp.key_status.set_register(0xFFFF);
-
-        for i in 0..2 {
-            temp.gpu.bg_affine_components[i].rotation_scaling_param_a.set_register(0x100);
-            temp.gpu.bg_affine_components[i].rotation_scaling_param_b.set_register(0);
-            temp.gpu.bg_affine_components[i].rotation_scaling_param_c.set_register(0);
-            temp.gpu.bg_affine_components[i].rotation_scaling_param_d.set_register(0x100);
-        }
+        temp.register_memory(pc_address);
 
         // setup the memory
         // General INternal Memory
@@ -93,6 +51,53 @@ impl GBA {
         temp.load_rom(&game_pack.rom);
 
         return temp;
+    }
+
+    pub fn register_memory(&mut self, pc_address: u32) {
+
+        self.gpu.register(&self.memory_bus.mem_map.memory);
+        self.key_status.register(&self.memory_bus.mem_map.memory);
+        self.ket_interrupt_control.register(&self.memory_bus.mem_map.memory);
+        self.interrupt_handler.ime_interrupt.register(&self.memory_bus.mem_map.memory);
+        self.interrupt_handler.ie_interrupt.register(&self.memory_bus.mem_map.memory);
+        self.interrupt_handler.if_interrupt.register(&self.memory_bus.mem_map.memory);
+        self.timer_handler.register(&self.memory_bus.mem_map.memory);
+        self.memory_bus.cycle_clock.register(&self.memory_bus.mem_map.memory);
+        self.dma_control.register(&self.memory_bus.mem_map.memory);
+
+        // setup the PC
+        self.cpu.set_register(ARM_PC, pc_address);
+        self.cpu.set_register(ARM_SP, 0x03007F00);
+
+        // setup the SPs'
+        self.cpu.set_operating_mode(OperatingMode::Interrupt);
+        self.cpu.set_register(ARM_SP, 0x03007FA0);
+
+        self.cpu.set_operating_mode(OperatingMode::FastInterrupt);
+        self.cpu.set_register(ARM_SP, 0x03007F00);
+
+        self.cpu.set_operating_mode(OperatingMode::User);
+        self.cpu.set_register(ARM_SP, 0x03007F00);
+
+        self.cpu.set_operating_mode(OperatingMode::Supervisor);
+        self.cpu.set_register(ARM_SP, 0x03007FE0);
+
+        self.cpu.set_operating_mode(OperatingMode::Abort);
+        self.cpu.set_register(ARM_SP, 0x03007F00);
+
+        self.cpu.set_operating_mode(OperatingMode::Undefined);
+        self.cpu.set_register(ARM_SP, 0x03007F00);
+
+        self.cpu.set_operating_mode(OperatingMode::Supervisor);
+
+        self.key_status.set_register(0xFFFF);
+
+        for i in 0..2 {
+            self.gpu.bg_affine_components[i].rotation_scaling_param_a.set_register(0x100);
+            self.gpu.bg_affine_components[i].rotation_scaling_param_b.set_register(0);
+            self.gpu.bg_affine_components[i].rotation_scaling_param_c.set_register(0);
+            self.gpu.bg_affine_components[i].rotation_scaling_param_d.set_register(0x100);
+        }
     }
 
     pub fn load_bios(&mut self, bios: &Vec<u8>) {

--- a/src/gba/mod.rs
+++ b/src/gba/mod.rs
@@ -7,8 +7,9 @@ use crate::interrupts::interrupts::Interrupts;
 use crate::dma::DMAController;
 use crate::timers::timer::TimerHandler;
 use crate::{gamepak::GamePack, gamepak::BackupType};
+use serde::{Serialize, Deserialize};
 
-
+#[derive(Serialize)]
 pub struct GBA {
     pub cpu: CPU,
     pub gpu: GPU,

--- a/src/gba/mod.rs
+++ b/src/gba/mod.rs
@@ -21,6 +21,13 @@ pub struct GBA {
     pub dma_control: DMAController
 }
 
+impl Default for GBA {
+    fn default() -> Self {
+        let temp = GamePack::default();
+        return GBA::new(0x08000000, &temp);
+    }
+}
+
 impl GBA {
 
     pub fn new(pc_address: u32, game_pack: &GamePack) -> GBA {

--- a/src/gpu/gpu.rs
+++ b/src/gpu/gpu.rs
@@ -41,7 +41,7 @@ pub enum GpuState {
     VBlank
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Background {
     pub control: BG_Control,
     pub horizontal_offset: BGOffset,
@@ -62,7 +62,7 @@ impl Background {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct BgAffineComponent {
     pub refrence_point_x_internal: u32,
     pub refrence_point_x_external: BGRefrencePoint,
@@ -87,7 +87,7 @@ impl BgAffineComponent {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Window {
     pub horizontal_dimensions: WindowHorizontalDimension,
     pub vertical_dimensions: WindowVerticalDimension
@@ -117,7 +117,7 @@ impl Window {
 }
 
 #[serde_as]
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GPU {
     pub display_control: DisplayControl,
     pub green_swap: GreenSwap,

--- a/src/gpu/gpu.rs
+++ b/src/gpu/gpu.rs
@@ -16,6 +16,8 @@ use std::{
     cell::RefCell,
     rc::Rc
 };
+use serde::{Serialize, Deserialize};
+use serde_with::{serde_as};
 use memory_macros::{gen_aff_matrix_array, gen_obj_array};
 
 gen_obj_array!();
@@ -23,6 +25,7 @@ gen_aff_matrix_array!();
 
 pub const DISPLAY_WIDTH: u32 = 240;
 pub const DISPLAY_HEIGHT: u32 = 160;
+pub const WINDOW_SIZE: usize = (DISPLAY_WIDTH as usize) * (DISPLAY_HEIGHT as usize);
 pub const VBLANK_LENGTH: u32 = 68;
 
 pub const HDRAW_CYCLES: i64 = 960;
@@ -31,13 +34,14 @@ pub const SCANLINE_CYCLES: i64 = 1232;
 pub const VDRAW_CYCLES: i64 = 197120;
 pub const VBLANK_CYCLES: i64 = 83776;
 
-#[derive(PartialEq)]
+#[derive(Serialize, Deserialize, PartialEq)]
 pub enum GpuState {
     HDraw,
     HBlank,
     VBlank
 }
 
+#[derive(Serialize)]
 pub struct Background {
     pub control: BG_Control,
     pub horizontal_offset: BGOffset,
@@ -58,6 +62,7 @@ impl Background {
     }
 }
 
+#[derive(Serialize)]
 pub struct BgAffineComponent {
     pub refrence_point_x_internal: u32,
     pub refrence_point_x_external: BGRefrencePoint,
@@ -82,6 +87,7 @@ impl BgAffineComponent {
     }
 }
 
+#[derive(Serialize)]
 pub struct Window {
     pub horizontal_dimensions: WindowHorizontalDimension,
     pub vertical_dimensions: WindowVerticalDimension
@@ -110,6 +116,8 @@ impl Window {
     }
 }
 
+#[serde_as]
+#[derive(Serialize)]
 pub struct GPU {
     pub display_control: DisplayControl,
     pub green_swap: GreenSwap,
@@ -119,8 +127,11 @@ pub struct GPU {
     pub backgrounds: [Background; 4],
     pub bg_affine_components: [BgAffineComponent; 2],
     pub windows: [Window; 2],
+
+    #[serde_as(as = "[_; WINDOW_SIZE]")]
     pub obj_window: [bool; (DISPLAY_WIDTH as usize) * (DISPLAY_HEIGHT as usize)],
 
+    #[serde_as(as = "[_; 128]")]
     pub objects: [Object; 128],
     pub aff_matrices: [AffineMatrix; 32],
 

--- a/src/gpu/graphic_effects.rs
+++ b/src/gpu/graphic_effects.rs
@@ -3,8 +3,9 @@ use crate::memory::memory_map::MemoryMap;
 use super::{rgb15::Rgb15, gpu::DISPLAY_WIDTH};
 use crate::memory::memory_map::PALETTE_RAM_START;
 use std::cmp;
+use serde::{Serialize, Deserialize};
 
-#[derive(PartialEq)]
+#[derive(Serialize, Deserialize, PartialEq)]
 pub enum BlendMode {
     Off,
     Alpha,
@@ -24,7 +25,7 @@ impl From<u8> for BlendMode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum WindowTypes {
     Window0,
     Window1,

--- a/src/gpu/object.rs
+++ b/src/gpu/object.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Object {
     pub attr0: ObjAttribute0,
     pub attr1: ObjAttribute1,
@@ -64,7 +64,7 @@ impl Object {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct AffineMatrix {
     pub pa: OBJRotScaleParam,
     pub pb: OBJRotScaleParam,

--- a/src/gpu/object.rs
+++ b/src/gpu/object.rs
@@ -9,7 +9,9 @@ use crate::memory::{
 };
 use std::cell::RefCell;
 use std::rc::Rc;
+use serde::{Serialize, Deserialize};
 
+#[derive(Serialize)]
 pub struct Object {
     pub attr0: ObjAttribute0,
     pub attr1: ObjAttribute1,
@@ -62,6 +64,7 @@ impl Object {
     }
 }
 
+#[derive(Serialize)]
 pub struct AffineMatrix {
     pub pa: OBJRotScaleParam,
     pub pb: OBJRotScaleParam,

--- a/src/gpu/rgb15.rs
+++ b/src/gpu/rgb15.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone, Copy)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct Rgb15 {
     pub red: u8,
     pub green: u8,

--- a/src/interrupts/interrupts.rs
+++ b/src/interrupts/interrupts.rs
@@ -3,11 +3,11 @@ use crate::memory::memory_bus::MemoryBus;
 use crate::memory::memory_map::HaltState;
 use crate::cpu::cpu;
 use crate::cpu::cpu::{OperatingMode, InstructionSet, ARM_LR, ARM_PC};
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 //use crate::cpu::InstructionSet;
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Interrupts {
     pub ime_interrupt: InterruptMasterEnableRegister,
     pub ie_interrupt: InterruptEnableRegister,

--- a/src/interrupts/interrupts.rs
+++ b/src/interrupts/interrupts.rs
@@ -3,9 +3,11 @@ use crate::memory::memory_bus::MemoryBus;
 use crate::memory::memory_map::HaltState;
 use crate::cpu::cpu;
 use crate::cpu::cpu::{OperatingMode, InstructionSet, ARM_LR, ARM_PC};
+use serde::Serialize;
 
 //use crate::cpu::InstructionSet;
 
+#[derive(Serialize)]
 pub struct Interrupts {
     pub ime_interrupt: InterruptMasterEnableRegister,
     pub ie_interrupt: InterruptEnableRegister,

--- a/src/memory/dma_registers.rs
+++ b/src/memory/dma_registers.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use memory_macros::*;
 use super::GbaMem;
+use serde::{Serialize, Deserialize};
 
 io_register! (
     DMASourceAddress => 4, [0x40000B0, 0x40000BC, 0x40000C8, 0x40000D4],

--- a/src/memory/interrupt_registers.rs
+++ b/src/memory/interrupt_registers.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use memory_macros::*;
 use super::GbaMem;
+use serde::{Serialize, Deserialize};
 
 io_register! (
     InterruptMasterEnableRegister => 4, 0x4000208,

--- a/src/memory/key_input_registers.rs
+++ b/src/memory/key_input_registers.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use memory_macros::*;
 use super::GbaMem;
+use serde::{Serialize, Deserialize};
 
 io_register! (
     KeyStatus => 2, 0x4000130,

--- a/src/memory/lcd_io_registers.rs
+++ b/src/memory/lcd_io_registers.rs
@@ -6,9 +6,10 @@ use crate::operations::bitutils::*;
 use super::GbaMem;
 use crate::gpu::graphic_effects::{BlendMode, WindowTypes};
 use memory_macros::*;
+use serde::{Serialize, Deserialize};
 
 #[repr(u8)]
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum PixelFormat {
     FourBit,
     EightBit

--- a/src/memory/memory_bus.rs
+++ b/src/memory/memory_bus.rs
@@ -3,7 +3,7 @@ use crate::operations::timing::{CycleClock, MemAccessSize};
 use crate::gamepak::BackupType;
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct MemoryBus {
     pub mem_map: MemoryMap,
     pub cycle_clock: CycleClock,

--- a/src/memory/memory_bus.rs
+++ b/src/memory/memory_bus.rs
@@ -1,7 +1,9 @@
 use crate::memory::memory_map::MemoryMap;
 use crate::operations::timing::{CycleClock, MemAccessSize};
 use crate::gamepak::BackupType;
+use serde::{Serialize, Deserialize};
 
+#[derive(Serialize)]
 pub struct MemoryBus {
     pub mem_map: MemoryMap,
     pub cycle_clock: CycleClock,

--- a/src/memory/memory_map.rs
+++ b/src/memory/memory_map.rs
@@ -2,6 +2,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use crate::gamepak::BackupType;
 use crate::gamepak::flash::Flash;
+use serde::{Serialize, Deserialize};
+use serde_with::serde_as;
 
 pub const ON_BOARD_WRAM_START: u32 = 0x02000000;
 pub const ON_BOARD_WRAM_SIZE: u32 = 0x3FFFF;
@@ -19,14 +21,16 @@ pub const ROM_SIZE: u32 = 0x1FF_FFFF;
 pub const SRAM_START: u32 = 0x0E000000;
 pub const SRAM_SIZE: u32 = 0xFFFF;
 
-#[derive(Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq)]
 pub enum HaltState {
     Running,
     Halt,
     Stop
 }
 
+#[derive(Serialize)]
 pub struct MemoryMap {
+    #[serde(skip)]
     pub memory: Rc<RefCell<Vec<u8>>>,
     pub halt_state: HaltState,
     pub backup_type: BackupType,

--- a/src/memory/memory_map.rs
+++ b/src/memory/memory_map.rs
@@ -299,6 +299,25 @@ impl<'de> Deserialize<'de> for MemoryMap {
                 formatter.write_str("struct MemoryMap")
             }
 
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: SeqAccess<'de>, {
+                let mem_vec = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let halt_state = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let backup_type = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let backed_up = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let flash = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+
+                let memory = Rc::new(RefCell::new(mem_vec));
+                Ok(MemoryMap {
+                    memory,
+                    halt_state,
+                    backup_type,
+                    backed_up,
+                    flash,
+                })
+            }
+
             fn visit_map<V>(self, mut map: V) -> Result<MemoryMap, V::Error>
             where
                 V: MapAccess<'de>,

--- a/src/memory/sound_registers.rs
+++ b/src/memory/sound_registers.rs
@@ -2,6 +2,7 @@ use wasm_bindgen::__rt::core::cell::RefCell;
 use wasm_bindgen::__rt::std::rc::Rc;
 use memory_macros::*;
 use super::GbaMem;
+use serde::{Serialize, Deserialize};
 
 
 /* ------------ Channels 1 and 2 ------------ */

--- a/src/memory/system_control.rs
+++ b/src/memory/system_control.rs
@@ -2,6 +2,7 @@ use wasm_bindgen::__rt::core::cell::RefCell;
 use wasm_bindgen::__rt::std::rc::Rc;
 use memory_macros::*;
 use super::GbaMem;
+use serde::{Serialize, Deserialize};
 
 io_register! (
     WaitStateControl => 2, 0x4000204,

--- a/src/memory/timer_registers.rs
+++ b/src/memory/timer_registers.rs
@@ -18,16 +18,24 @@ io_register! (
 
 impl TimerDataRegister {
     pub fn get_reload(&self) -> u16 {
-        let mem_ref = self.memory.borrow();
-        let address = 0x1000_0000 + (TimerDataRegister::SEGMENT_INDICIES[self.index] & 0xF); 
-        return (mem_ref[address] as u32 | ((mem_ref[address + 1] as u32) << 8)) as u16;
+        if let Some(mem) = &self.memory {
+            let mem_ref = mem.borrow();
+            let address = 0x1000_0000 + (TimerDataRegister::SEGMENT_INDICIES[self.index] & 0xF); 
+            return (mem_ref[address] as u32 | ((mem_ref[address + 1] as u32) << 8)) as u16;
+        } else {
+            panic!("IO register was accessed without being registered");
+        }
     }
 
     pub fn write_reload(&mut self, value: u16) {
-        let mut mem_ref = self.memory.borrow_mut();
-        let address = 0x1000_0000 + (self.index * 2); 
+        if let Some(mem) = &self.memory {
+            let mut mem_ref = mem.borrow_mut();
+            let address = 0x1000_0000 + (self.index * 2); 
 
-        mem_ref[address] = (value & 0xFF) as u8;
-        mem_ref[address + 1] = ((value & 0xFF00) >> 8) as u8;
+            mem_ref[address] = (value & 0xFF) as u8;
+            mem_ref[address + 1] = ((value & 0xFF00) >> 8) as u8;
+        } else {
+            panic!("IO register was accessed without being registered");
+        }
     }
 }

--- a/src/memory/timer_registers.rs
+++ b/src/memory/timer_registers.rs
@@ -2,6 +2,7 @@ use wasm_bindgen::__rt::core::cell::RefCell;
 use wasm_bindgen::__rt::std::rc::Rc;
 use memory_macros::*;
 use super::GbaMem;
+use serde::{Serialize, Deserialize};
 
 io_register! (
     TimerDataRegister => 2, [0x4000100, 0x4000104, 0x4000108, 0x400010C],

--- a/src/operations/timing.rs
+++ b/src/operations/timing.rs
@@ -1,10 +1,13 @@
 use crate::memory::system_control::WaitStateControl;
 use std::cell::RefCell;
 use std::rc::Rc;
+use serde::{Serialize, Deserialize};
 
+#[derive(Serialize)]
 pub struct CycleClock {
     pub prev_address: u32,
     pub cycles: u32,
+    #[serde(skip)]
     pub wait_state_control: WaitStateControl,
 }
 
@@ -144,6 +147,16 @@ impl CycleClock {
             return CycleType::S;
         }
         return CycleType::N;
+    }
+}
+
+impl Default for CycleClock {
+    fn default() -> Self {
+        CycleClock {
+            prev_address: 0,
+            cycles: 0,
+            wait_state_control: WaitStateControl::new(),
+        }
     }
 }
 

--- a/src/operations/timing.rs
+++ b/src/operations/timing.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CycleClock {
     pub prev_address: u32,
     pub cycles: u32,
@@ -25,14 +25,14 @@ pub const GAMEPAK_WS1_HI: u32 = 0x0B00_0000;
 pub const GAMEPAK_WS2_START: u32 = 0x0C00_0000;
 pub const GAMEPAK_WS2_HI: u32 = 0x0D00_0000;
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 pub enum MemAccessSize {
     Mem8,
     Mem16,
     Mem32,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 pub enum CycleType {
     N,
     S,

--- a/src/timers/timer.rs
+++ b/src/timers/timer.rs
@@ -2,9 +2,9 @@ use crate::memory::timer_registers::*;
 use crate::interrupts::interrupts::Interrupts;
 use std::cell::RefCell;
 use std::rc::Rc;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Timer {
     pub timer: TimerDataRegister,
     pub controller: TimerControlRegister,
@@ -84,7 +84,7 @@ impl Timer {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct TimerHandler {
     pub timers: [Timer; 4],
     pub running_timers: u8

--- a/src/timers/timer.rs
+++ b/src/timers/timer.rs
@@ -2,7 +2,9 @@ use crate::memory::timer_registers::*;
 use crate::interrupts::interrupts::Interrupts;
 use std::cell::RefCell;
 use std::rc::Rc;
+use serde::Serialize;
 
+#[derive(Serialize)]
 pub struct Timer {
     pub timer: TimerDataRegister,
     pub controller: TimerControlRegister,
@@ -82,6 +84,7 @@ impl Timer {
     }
 }
 
+#[derive(Serialize)]
 pub struct TimerHandler {
     pub timers: [Timer; 4],
     pub running_timers: u8


### PR DESCRIPTION
Added save states using serde to serialize the entire GBA struct. Broke out memory registration as its own function in the gba so that we can register the io_registers after de serialization. Also added a custom serialize/deserialize for the main memory block. There wast a default implementation for serializing/deserializing an Rc<RefCell<Vec<u8>>>

Minifb PR that uses this: https://github.com/gba-rs/minifb-frontend/pull/4

https://github.com/user-attachments/assets/c5c0817b-4fc7-4d8e-9589-0c8b2f196871